### PR TITLE
Update TravelTime API spec to version 1.3.0

### DIFF
--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -2098,6 +2098,56 @@ components:
           items:
             $ref: '#/components/schemas/ResponseRoutesResult'
 
+    ResponseRoutesGetProperties:
+      type: object
+      properties:
+        travel_time:
+          $ref: '#/components/schemas/ResponseTravelTime'
+        distance:
+          $ref: '#/components/schemas/ResponseDistance'
+        route:
+          $ref: '#/components/schemas/ResponseRoute'
+
+    ResponseRoutesGetLocation:
+      type: object
+      required:
+        - id
+        - properties
+      properties:
+        id:
+          type: string
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseRoutesGetProperties'
+
+    ResponseRoutesGetResult:
+      type: object
+      required:
+        - search_id
+        - locations
+      properties:
+        search_id:
+          type: string
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseRoutesGetLocation'
+        unreachable:
+          type: array
+          items:
+            type: string
+
+    ResponseRoutesGetResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseRoutesGetResult'
+
     ResponseTimeMapResult:
       type: object
       required:
@@ -2840,7 +2890,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseRoutesResponse'
+                $ref: '#/components/schemas/ResponseRoutesGetResponse'
         '400':
           description: Bad request
           content:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -661,7 +661,7 @@ components:
           properties:
             enabled:
               type: boolean
-              description: Enable transit leg change limit?
+              description: Enable transit leg change limit
             limit:
               type: integer
               description: Maximum number of changes between transit legs in a journey.

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -236,7 +236,7 @@ components:
           description: Maximum distance in meters between locations and the nearest accessible road. Default is 1000 meters. Departure locations exceeding this return errors, arrival locations return unreachable results
           default: 1000
     
-    RequestSnappingH3:
+    RequestSnappingH3AndGeohash:
       type: object
       properties:
         penalty:
@@ -1290,7 +1290,7 @@ components:
         range:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         snapping:
-          $ref: '#/components/schemas/RequestSnappingH3'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
         remove_water_bodies:
           type: boolean
           description: Remove water bodies from the results
@@ -1317,7 +1317,7 @@ components:
         range:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         snapping:
-          $ref: '#/components/schemas/RequestSnappingH3'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
         remove_water_bodies:
           type: boolean
           description: Remove water bodies from the results
@@ -1375,7 +1375,7 @@ components:
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         snapping:
-          $ref: '#/components/schemas/RequestSnappingH3'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
 
     RequestH3FastArrivalOneToManySearch:
       type: object
@@ -1397,7 +1397,7 @@ components:
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         snapping:
-          $ref: '#/components/schemas/RequestSnappingH3'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
 
     RequestH3FastArrivalSearches:
       type: object
@@ -1481,7 +1481,7 @@ components:
         range:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
         remove_water_bodies:
           type: boolean
           description: Remove water bodies from the results
@@ -1508,7 +1508,7 @@ components:
         range:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
         remove_water_bodies:
           type: boolean
           description: Remove water bodies from the results
@@ -1566,7 +1566,7 @@ components:
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
 
     RequestGeohashFastArrivalOneToManySearch:
       type: object
@@ -1588,7 +1588,7 @@ components:
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3AndGeohash'
 
     RequestGeohashFastArrivalSearches:
       type: object

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -587,6 +587,39 @@ components:
           items:
             $ref: '#/components/schemas/RequestTimeFilterFastProperty'
 
+    RequestTransportationDistanceMap:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - driving
+            - walking
+            - cycling
+            - driving+ferry
+            - cycling+ferry
+            - ferry
+          description: Mode of transportation for distance map
+        boarding_time:
+          type: integer
+          description: Time in seconds for boarding
+          default: 0
+          maximum: 3600
+        disable_border_crossing:
+          type: boolean
+          description: Disable crossing country borders (driving only)
+          default: false
+        include_roads:
+          type: array
+          items:
+            type: string
+            enum:
+              - track
+              - restricted
+          description: Additional road types to include when executing search. Only affects driving and driving+ferry transportation modes. track = unpaved roads that only allow very slow driving speed or may require an off-road capable vehicle. restricted = roads that are not publicly accessible and may require a special permit. By default all of these roads are excluded from the search.
+
     RequestTransportation:
       type: object
       required:
@@ -1042,7 +1075,7 @@ components:
         coords:
           $ref: '#/components/schemas/Coords'
         transportation:
-          $ref: '#/components/schemas/RequestTransportation'
+          $ref: '#/components/schemas/RequestTransportationDistanceMap'
         travel_distance:
           $ref: '#/components/schemas/RequestTravelDistance'
         departure_time:
@@ -1071,7 +1104,7 @@ components:
         coords:
           $ref: '#/components/schemas/Coords'
         transportation:
-          $ref: '#/components/schemas/RequestTransportation'
+          $ref: '#/components/schemas/RequestTransportationDistanceMap'
         travel_distance:
           $ref: '#/components/schemas/RequestTravelDistance'
         arrival_time:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -1,4 +1,4 @@
-openapi: "3.1.0"
+openapi: "3.1.1"
 
 info:
   title: TravelTime API
@@ -98,6 +98,24 @@ components:
       maximum: 14400
       description: Maximum travel time in seconds (1 minute to 4 hours)
 
+    RequestTravelTimeFast:
+      type: integer
+      minimum: 60
+      maximum: 10800
+      description: Maximum travel time in seconds (1 minute to 3 hours)
+
+    RequestTravelTimeH3Fast:
+      type: integer
+      minimum: 60
+      maximum: 10800
+      description: Maximum travel time in seconds (up to 3 hours). Note that the actual maximum depends on the resolution parameter. Limitations can be found at https://docs.traveltime.com/api/reference/h3-fast#limits-of-resolution-and-traveltime
+
+    RequestTravelTimeH3:
+      type: integer
+      minimum: 60
+      maximum: 36000
+      description: Maximum travel time in seconds (up to 10 hours). Note that the actual maximum depends on the resolution parameter. Limitations can be found at https://docs.traveltime.com/api/reference/h3#limits-of-resolution-and-traveltime
+
     RequestTravelDistance:
       type: integer
       minimum: 75
@@ -178,12 +196,23 @@ components:
           enum:
             - enabled
             - disabled
-          description: Control road network lookup behavior
+          description: |
+            Controls whether walking distances to/from the nearest road are included in travel time/distance.
+            - enabled (default): Walking time/distance from departure to nearest road and from nearest road to arrival are added to totals
+            - disabled: Journey starts/ends at the nearest road network point, excluding walking portions
         accept_roads:
-          type: array
-          items:
-            type: string
-          description: List of road types to accept
+          type: string
+          enum:
+            - both_drivable_and_walkable
+            - any_drivable
+          description: |
+            Controls which road types can serve as journey start/end points.
+            - both_drivable_and_walkable (default): Only roads accessible by both cars and pedestrians, preventing routes from starting/ending on motorways
+            - any_drivable: Any road accessible by car, including motorways
+        threshold:
+          type: integer
+          description: Maximum distance in meters between locations and the nearest accessible road. Default is 1000 meters. Departure locations exceeding this return errors, arrival locations return unreachable results
+          default: 1000
 
     RequestTimeFilterPostcodesProperty:
       type: string
@@ -247,6 +276,8 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterPostcodeSectorsProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
     
     RequestTimeFilterPostcodeSectorsArrivalSearch:
       type: object
@@ -277,12 +308,14 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterPostcodeSectorsProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
     
     RequestTimeFilterPostcodeDistrictsDepartureSearch:
       type: object
       required:
         - id
-        - coords        
+        - coords
         - transportation
         - travel_time
         - departure_time
@@ -307,12 +340,14 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterPostcodeDistrictsProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
     
     RequestTimeFilterPostcodeDistrictsArrivalSearch:
       type: object
       required:
         - id
-        - coords        
+        - coords
         - transportation
         - travel_time
         - arrival_time
@@ -337,12 +372,14 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterPostcodeDistrictsProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
     
     RequestTimeFilterPostcodesDepartureSearch:
       type: object
       required:
         - id
-        - coords        
+        - coords
         - transportation
         - travel_time
         - departure_time
@@ -364,12 +401,14 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterPostcodesProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
     
     RequestTimeFilterPostcodesArrivalSearch:
       type: object
       required:
         - id
-        - coords        
+        - coords
         - transportation
         - travel_time
         - arrival_time
@@ -391,6 +430,8 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterPostcodesProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
     
     RequestTimeFilterDepartureSearch:
       type: object
@@ -474,7 +515,13 @@ components:
       type: string
       enum:
         - travel_time
+        - distance
         - fares
+      description: |
+        Properties to return for fast time filter searches.
+        - travel_time: Travel duration in seconds
+        - distance: Journey distance in meters (only available for driving+ferry, cycling+ferry, and walking+ferry transportation types)
+        - fares: Pricing information (UK locations only)
     
     RequestTimeFilterFastArrivalManyToOneSearch:
       type: object
@@ -500,7 +547,7 @@ components:
         transportation:
           $ref: '#/components/schemas/RequestTransportationFast'
         travel_time:
-          $ref: '#/components/schemas/RequestTravelTime'
+          $ref: '#/components/schemas/RequestTravelTimeFast'
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         properties:
@@ -532,7 +579,7 @@ components:
         transportation:
           $ref: '#/components/schemas/RequestTransportationFast'
         travel_time:
-          $ref: '#/components/schemas/RequestTravelTime'
+          $ref: '#/components/schemas/RequestTravelTimeFast'
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         properties:
@@ -551,6 +598,7 @@ components:
             - cycling
             - driving
             - driving+train
+            - driving+public_transport
             - public_transport
             - walking
             - coach
@@ -582,6 +630,21 @@ components:
         disable_border_crossing:
           type: boolean
           description: Disable crossing country borders (driving only)
+        include_roads:
+          type: array
+          items:
+            type: string
+            enum:
+              - track
+              - restricted
+          description: Additional road types to include when executing search. Only affects driving and driving+ferry transportation modes. track = unpaved roads that only allow very slow driving speed or may require an off-road capable vehicle. restricted = roads that are not publicly accessible and may require a special permit. By default all of these roads are excluded from the search.
+        traffic_model:
+          type: string
+          enum:
+            - balanced
+            - optimistic
+            - pessimistic
+          description: Specifies how traffic conditions are accounted for in driving modes. balanced (default) = uses typical traffic conditions. optimistic = uses lighter traffic conditions, resulting in shorter travel times. pessimistic = uses heavier traffic conditions, resulting in longer travel times. Used in driving, driving+ferry, driving+train, and driving+public_transport transportation modes.
         max_changes:
           type: object
           properties:
@@ -599,14 +662,17 @@ components:
           type: string
           enum:
             - public_transport
-            - driving
-            - cycling
-            - walking
             - walking+ferry
             - cycling+ferry
             - driving+ferry
             - driving+public_transport
           description: Transportation mode for fast endpoints
+        traffic_model:
+          type: string
+          enum:
+            - peak
+            - off_peak
+          description: Determines the level of traffic used in driving journeys. peak (default) = represents typical traffic conditions for a midweek morning. off_peak = represents typical traffic conditions at night time. Can only be specified with driving+ferry and driving+public_transport transportation types.
     
     RequestRoutesDepartureSearch:
       type: object
@@ -676,6 +742,7 @@ components:
 
     RequestTimeFilter:
       type: object
+      description: At least one of departure_searches or arrival_searches must contain items
       required:
         - locations
       properties:
@@ -697,6 +764,7 @@ components:
     
     RequestTimeFilterPostcodes:
       type: object
+      description: At least one of departure_searches or arrival_searches must contain items
       properties:
         departure_searches:
           type: array
@@ -711,6 +779,7 @@ components:
 
     RequestTimeFilterPostcodeDistricts:
       type: object
+      description: At least one of departure_searches or arrival_searches must contain items
       properties:
         departure_searches:
           type: array
@@ -725,6 +794,7 @@ components:
 
     RequestTimeFilterPostcodeSectors:
       type: object
+      description: At least one of departure_searches or arrival_searches must contain items
       properties:
         departure_searches:
           type: array
@@ -739,6 +809,7 @@ components:
 
     RequestTimeFilterFastArrivalSearches:
       type: object
+      description: At least one of many_to_one or one_to_many must contain items
       properties:
         many_to_one:
           type: array
@@ -767,6 +838,7 @@ components:
 
     RequestRoutes:
       type: object
+      description: At least one of departure_searches or arrival_searches must contain items
       required:
         - locations
       properties:
@@ -800,27 +872,34 @@ components:
             - simple
             - simple_numeric
             - coarse_grid
-          description: Type of scale for level of detail
+          description: Type of scale for level of detail. simple = level specified using simple enumeration. simple_numeric = level specified using integers (extension of simple scale). coarse_grid = level specified as a number to simplify shape to a grid density.
         level:
-          type: string
-          enum:
-            - lowest
-            - low
-            - medium
-            - high
-            - highest
-          description: Level of detail for the polygon
+          oneOf:
+            - type: string
+              enum:
+                - lowest
+                - low
+                - medium
+                - high
+                - highest
+              description: Used with simple scale_type
+            - type: integer
+              minimum: -20
+              maximum: 2
+              description: Used with simple_numeric scale_type. Lower numbers = less detail. Values -2 to 2 are equivalent to lowest to highest of simple scale.
+          description: Level of detail for the polygon. Can be string (for simple scale) or integer (for simple_numeric scale).
+        square_size:
+          type: integer
+          minimum: 600
+          description: Used with coarse_grid scale_type. Specifies the side length (in meters) of the squares used to construct the shape. Larger values = less detailed shape.
 
     RequestPolygonsFilter:
       type: object
       properties:
-        largest_area:
-          type: boolean
-          description: Only return the largest polygon
-        smallest_inner_area:
-          type: number
-          format: double
-          description: Minimum area of inner holes to include
+        limit:
+          type: integer
+          minimum: 1
+          description: At most this amount of largest polygons will be returned in a single shape. Must be greater than 0.
 
     RequestUnionOnIntersection:
       type: object
@@ -867,9 +946,18 @@ components:
           $ref: '#/components/schemas/RequestSnapping'
         polygons_filter:
           $ref: '#/components/schemas/RequestPolygonsFilter'
+        no_holes:
+          type: boolean
+          description: Enable to remove holes from returned polygons. Note that this will likely result in loss in accuracy.
+        render_mode:
+          type: string
+          enum:
+            - approximate_time_filter
+            - road_buffering
+          description: Controls how the shape is rendered. approximate_time_filter (default) = shape matches time-filter results as much as possible. road_buffering = shape looks as if traversed roads have been painted over with a wide brush.
         remove_water_bodies:
           type: boolean
-          description: Remove water bodies from the polygons
+          description: If true (default), returned shape will not cover large nearby water bodies. If false, shape may cover nearby water bodies like large lakes, wide rivers and seas.
 
     RequestTimeMapArrivalSearch:
       type: object
@@ -902,11 +990,22 @@ components:
           $ref: '#/components/schemas/RequestSnapping'
         polygons_filter:
           $ref: '#/components/schemas/RequestPolygonsFilter'
+        no_holes:
+          type: boolean
+          description: Enable to remove holes from returned polygons. Note that this will likely result in loss in accuracy.
+        render_mode:
+          type: string
+          enum:
+            - approximate_time_filter
+            - road_buffering
+          description: Controls how the shape is rendered. approximate_time_filter (default) = shape matches time-filter results as much as possible. road_buffering = shape looks as if traversed roads have been painted over with a wide brush.
         remove_water_bodies:
           type: boolean
+          description: If true (default), returned shape will not cover large nearby water bodies. If false, shape may cover nearby water bodies like large lakes, wide rivers and seas.
 
     RequestTimeMap:
       type: object
+      description: At least one of departure_searches or arrival_searches must contain items
       properties:
         departure_searches:
           type: array
@@ -950,60 +1049,543 @@ components:
           $ref: '#/components/schemas/RequestDepartureArrivalTime'
         level_of_detail:
           $ref: '#/components/schemas/RequestLevelOfDetail'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        polygons_filter:
+          $ref: '#/components/schemas/RequestPolygonsFilter'
+        no_holes:
+          type: boolean
+          description: Enable to remove holes from returned polygons. Note that this will likely result in loss in accuracy.
+
+    RequestDistanceMapArrivalSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - travel_distance
+        - arrival_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportation'
+        travel_distance:
+          $ref: '#/components/schemas/RequestTravelDistance'
+        arrival_time:
+          $ref: '#/components/schemas/RequestDepartureArrivalTime'
+        level_of_detail:
+          $ref: '#/components/schemas/RequestLevelOfDetail'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        polygons_filter:
+          $ref: '#/components/schemas/RequestPolygonsFilter'
+        no_holes:
+          type: boolean
+          description: Enable to remove holes from returned polygons. Note that this will likely result in loss in accuracy.
 
     RequestDistanceMap:
       type: object
-      required:
-        - departure_searches
       properties:
         departure_searches:
           type: array
           maxItems: 10
           items:
             $ref: '#/components/schemas/RequestDistanceMapDepartureSearch'
+        arrival_searches:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestDistanceMapArrivalSearch'
+        unions:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+          description: Define the unions of shapes from previously defined departure or arrival searches
+        intersections:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+          description: Define the intersections of shapes from previously defined departure or arrival searches
 
-    RequestGeocodingSearch:
+    RequestRenderMode:
+      type: string
+      enum:
+        - approximate_time_filter
+        - road_buffering
+      description: Rendering mode for time-map/fast
+
+    RequestTimeMapFastArrivalManyToOneSearch:
       type: object
       required:
-        - query
+        - id
+        - coords
+        - transportation
+        - arrival_time_period
+        - travel_time
       properties:
-        query:
-          type: string
-          description: Address, postcode, or venue to geocode
-        within_country:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportationFast'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeFast'
+        arrival_time_period:
+          $ref: '#/components/schemas/RequestArrivalTimePeriod'
+        level_of_detail:
+          $ref: '#/components/schemas/RequestLevelOfDetail'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        polygons_filter:
+          $ref: '#/components/schemas/RequestPolygonsFilter'
+        no_holes:
+          type: boolean
+          description: Remove holes from polygons
+        render_mode:
+          $ref: '#/components/schemas/RequestRenderMode'
+
+    RequestTimeMapFastArrivalOneToManySearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - arrival_time_period
+        - travel_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportationFast'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeFast'
+        arrival_time_period:
+          $ref: '#/components/schemas/RequestArrivalTimePeriod'
+        level_of_detail:
+          $ref: '#/components/schemas/RequestLevelOfDetail'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        polygons_filter:
+          $ref: '#/components/schemas/RequestPolygonsFilter'
+        no_holes:
+          type: boolean
+          description: Remove holes from polygons
+        render_mode:
+          $ref: '#/components/schemas/RequestRenderMode'
+
+    RequestTimeMapFastArrivalSearches:
+      type: object
+      description: At least one of many_to_one or one_to_many must contain items
+      properties:
+        many_to_one:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestTimeMapFastArrivalManyToOneSearch'
+        one_to_many:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestTimeMapFastArrivalOneToManySearch'
+
+    RequestTimeMapFast:
+      type: object
+      required:
+        - arrival_searches
+      properties:
+        arrival_searches:
+          $ref: '#/components/schemas/RequestTimeMapFastArrivalSearches'
+
+    RequestH3Resolution:
+      type: string
+      enum:
+        - "6"
+        - "7"
+        - "8"
+        - "9"
+        - "10"
+        - "11"
+        - "12"
+      description: H3 cell resolution level (6-12). Refer to relevant docs for limitations
+
+    RequestH3Property:
+      type: string
+      enum:
+        - min
+        - max
+        - mean
+      description: H3 cell properties to return
+
+    RequestH3DepartureSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - travel_time
+        - departure_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportation'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeH3'
+        departure_time:
+          $ref: '#/components/schemas/RequestDepartureArrivalTime'
+        range:
+          $ref: '#/components/schemas/RequestRangeNoMaxResults'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        remove_water_bodies:
+          type: boolean
+          description: Remove water bodies from the results
+
+    RequestH3ArrivalSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - travel_time
+        - arrival_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportation'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeH3'
+        arrival_time:
+          $ref: '#/components/schemas/RequestDepartureArrivalTime'
+        range:
+          $ref: '#/components/schemas/RequestRangeNoMaxResults'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        remove_water_bodies:
+          type: boolean
+          description: Remove water bodies from the results
+
+    RequestH3:
+      type: object
+      required:
+        - resolution
+        - properties
+      properties:
+        resolution:
+          $ref: '#/components/schemas/RequestH3Resolution'
+        properties:
           type: array
           items:
-            type: string
-          description: Restrict results to specific countries (ISO 3166-1 alpha-2 or alpha-3)
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 50
-          description: Maximum number of results to return
-        bounds:
-          type: string
-          description: Bounding box to restrict results (min-lat,min-lng,max-lat,max-lng)
-        format_name:
-          type: boolean
-          description: Format the name field as a well-formatted address
-        format_exclude_country:
-          type: boolean
-          description: Exclude country from formatted name
+            $ref: '#/components/schemas/RequestH3Property'
+        departure_searches:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestH3DepartureSearch'
+        arrival_searches:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestH3ArrivalSearch'
+        unions:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+        intersections:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
 
-    RequestReverseGeocodingSearch:
+    RequestH3FastArrivalManyToOneSearch:
       type: object
       required:
-        - lat
-        - lng
+        - id
+        - coords
+        - transportation
+        - arrival_time_period
+        - travel_time
       properties:
-        lat:
-          type: number
-          format: double
-          description: Latitude of the location
-        lng:
-          type: number
-          format: double
-          description: Longitude of the location
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportationFast'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeH3Fast'
+        arrival_time_period:
+          $ref: '#/components/schemas/RequestArrivalTimePeriod'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+
+    RequestH3FastArrivalOneToManySearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - arrival_time_period
+        - travel_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportationFast'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeH3Fast'
+        arrival_time_period:
+          $ref: '#/components/schemas/RequestArrivalTimePeriod'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+
+    RequestH3FastArrivalSearches:
+      type: object
+      description: At least one of many_to_one or one_to_many must contain items
+      properties:
+        many_to_one:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestH3FastArrivalManyToOneSearch'
+        one_to_many:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestH3FastArrivalOneToManySearch'
+
+    RequestH3Fast:
+      type: object
+      required:
+        - resolution
+        - properties
+        - arrival_searches
+      properties:
+        resolution:
+          $ref: '#/components/schemas/RequestH3Resolution'
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequestH3Property'
+        arrival_searches:
+          $ref: '#/components/schemas/RequestH3FastArrivalSearches'
+        unions:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+        intersections:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+
+    RequestGeohashResolution:
+      type: string
+      enum:
+        - "1"
+        - "2"
+        - "3"
+        - "4"
+        - "5"
+        - "6"
+      description: Geohash cell resolution level
+
+    RequestGeohashProperty:
+      type: string
+      enum:
+        - min
+        - max
+        - mean
+      description: Geohash cell properties to return
+
+    RequestGeohashDepartureSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - travel_time
+        - departure_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportation'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTime'
+        departure_time:
+          $ref: '#/components/schemas/RequestDepartureArrivalTime'
+        range:
+          $ref: '#/components/schemas/RequestRangeNoMaxResults'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        remove_water_bodies:
+          type: boolean
+          description: Remove water bodies from the results
+
+    RequestGeohashArrivalSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - travel_time
+        - arrival_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportation'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTime'
+        arrival_time:
+          $ref: '#/components/schemas/RequestDepartureArrivalTime'
+        range:
+          $ref: '#/components/schemas/RequestRangeNoMaxResults'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        remove_water_bodies:
+          type: boolean
+          description: Remove water bodies from the results
+
+    RequestGeohash:
+      type: object
+      required:
+        - resolution
+        - properties
+      properties:
+        resolution:
+          $ref: '#/components/schemas/RequestGeohashResolution'
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequestGeohashProperty'
+        departure_searches:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestGeohashDepartureSearch'
+        arrival_searches:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestGeohashArrivalSearch'
+        unions:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+        intersections:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+
+    RequestGeohashFastArrivalManyToOneSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - arrival_time_period
+        - travel_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportationFast'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeFast'
+        arrival_time_period:
+          $ref: '#/components/schemas/RequestArrivalTimePeriod'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+
+    RequestGeohashFastArrivalOneToManySearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - arrival_time_period
+        - travel_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportationFast'
+        travel_time:
+          $ref: '#/components/schemas/RequestTravelTimeFast'
+        arrival_time_period:
+          $ref: '#/components/schemas/RequestArrivalTimePeriod'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+
+    RequestGeohashFastArrivalSearches:
+      type: object
+      description: At least one of many_to_one or one_to_many must contain items
+      properties:
+        many_to_one:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestGeohashFastArrivalManyToOneSearch'
+        one_to_many:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestGeohashFastArrivalOneToManySearch'
+
+    RequestGeohashFast:
+      type: object
+      required:
+        - resolution
+        - properties
+        - arrival_searches
+      properties:
+        resolution:
+          $ref: '#/components/schemas/RequestGeohashResolution'
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequestGeohashProperty'
+        arrival_searches:
+          $ref: '#/components/schemas/RequestGeohashFastArrivalSearches'
+        unions:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
+        intersections:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestUnionOnIntersection'
 
     RequestSupportedLocations:
       type: object
@@ -1012,6 +1594,7 @@ components:
       properties:
         locations:
           type: array
+          minItems: 1
           items:
             $ref: '#/components/schemas/RequestLocation'
 
@@ -1301,6 +1884,8 @@ components:
       properties:
         travel_time:
           $ref: '#/components/schemas/ResponseTravelTime'
+        distance:
+          $ref: '#/components/schemas/ResponseDistance'
         fares:
           $ref: '#/components/schemas/ResponseFaresFast'
 
@@ -1473,6 +2058,100 @@ components:
         attribution:
           type: string
 
+    ResponseH3Properties:
+      type: object
+      properties:
+        min:
+          type: integer
+          description: Minimum travel time in seconds
+        max:
+          type: integer
+          description: Maximum travel time in seconds
+        mean:
+          type: integer
+          description: Mean travel time in seconds
+
+    ResponseH3Cell:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: H3 cell identifier
+        properties:
+          $ref: '#/components/schemas/ResponseH3Properties'
+
+    ResponseH3Result:
+      type: object
+      required:
+        - search_id
+        - cells
+      properties:
+        search_id:
+          type: string
+        cells:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseH3Cell'
+
+    ResponseH3Response:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseH3Result'
+
+    ResponseGeohashProperties:
+      type: object
+      properties:
+        min:
+          type: integer
+          description: Minimum travel time in seconds
+        max:
+          type: integer
+          description: Maximum travel time in seconds
+        mean:
+          type: integer
+          description: Mean travel time in seconds
+
+    ResponseGeohashCell:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Geohash cell identifier
+        properties:
+          $ref: '#/components/schemas/ResponseGeohashProperties'
+
+    ResponseGeohashResult:
+      type: object
+      required:
+        - search_id
+        - cells
+      properties:
+        search_id:
+          type: string
+        cells:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseGeohashCell'
+
+    ResponseGeohashResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseGeohashResult'
+
     ResponseSupportedLocation:
       type: object
       required:
@@ -1508,10 +2187,36 @@ components:
       properties:
         fares:
           type: boolean
-        postcodes:
+          description: Indicates whether or not we have fare data
+        postcode:
           type: boolean
+          description: Indicates whether or not postcode searches are supported
         public_transport:
-          type: boolean
+          type: object
+          description: Public transport support information. Public transport is not supported if this object is missing.
+          properties:
+            date_start:
+              type: string
+              format: date-time
+              description: Start date of public transport data availability
+            date_end:
+              type: string
+              format: date-time
+              description: End date of public transport data availability
+        time_filter_fast:
+          type: object
+          description: Fast time-filter support information. The endpoint is not supported if this object is missing.
+          properties:
+            periods:
+              type: array
+              items:
+                type: object
+                description: Each entry describes a time period and time filter modes that are available for this country
+        cross_country_modes:
+          type: array
+          items:
+            type: string
+          description: Array of supported transportation modes while doing cross country search
 
     ResponseMapInfoMap:
       type: object
@@ -1584,6 +2289,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '429':
           description: Too many requests
           content:
@@ -1619,6 +2330,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/time-filter/postcodes:
     post:
@@ -1638,6 +2361,18 @@ paths:
           description: Successful response
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
           content:
             application/json:
               schema:
@@ -1665,6 +2400,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/time-filter/postcode-sectors:
     post:
@@ -1684,6 +2431,18 @@ paths:
           description: Successful response
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
           content:
             application/json:
               schema:
@@ -1713,6 +2472,18 @@ paths:
                 $ref: '#/components/schemas/ResponseRoutesResponse'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
           content:
             application/json:
               schema:
@@ -1750,6 +2521,63 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/time-map/fast:
+    post:
+      tags:
+        - Time Map
+      summary: Time Map Fast
+      description: |
+        High-performance endpoint for generating isochrone polygons using pre-computed data.
+        Faster response times than the standard time-map endpoint.
+      operationId: timeMapFast
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeMapFast'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeMapResponse'
+            application/geo+json:
+              schema:
+                type: object
+                description: GeoJSON FeatureCollection with isochrone polygons
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/distance-map:
     post:
@@ -1779,6 +2607,182 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/h3:
+    post:
+      tags:
+        - Specialized Analysis
+      summary: H3 Grid Analysis
+      description: |
+        Calculate travel times to H3 cells within a catchment area.
+        Returns min, max, and mean travel times for each H3 cell.
+      operationId: h3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestH3'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseH3Response'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/h3/fast:
+    post:
+      tags:
+        - Specialized Analysis
+      summary: H3 Grid Analysis Fast
+      description: |
+        High-performance endpoint for calculating travel times to H3 cells.
+        Uses pre-computed data for faster response times.
+      operationId: h3Fast
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestH3Fast'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseH3Response'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/geohash:
+    post:
+      tags:
+        - Specialized Analysis
+      summary: Geohash Grid Analysis
+      description: |
+        Calculate travel times to geohash cells within a catchment area.
+        Returns min, max, and mean travel times for each geohash cell.
+      operationId: geohash
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestGeohash'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseGeohashResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/geohash/fast:
+    post:
+      tags:
+        - Specialized Analysis
+      summary: Geohash Grid Analysis Fast
+      description: |
+        High-performance endpoint for calculating travel times to geohash cells.
+        Uses pre-computed data for faster response times.
+      operationId: geohashFast
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestGeohashFast'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseGeohashResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/geocoding/search:
     get:
@@ -1793,6 +2797,7 @@ paths:
           required: true
           schema:
             type: string
+            minLength: 1
           description: Address, postcode, or venue to geocode
         - name: within.country
           in: query
@@ -1800,7 +2805,7 @@ paths:
             type: array
             items:
               type: string
-          description: Restrict results to specific countries
+          description: Restrict results to specific countries (ISO 3166-1 alpha-2 or alpha-3)
         - name: limit
           in: query
           schema:
@@ -1812,7 +2817,22 @@ paths:
           in: query
           schema:
             type: string
-          description: Bounding box to restrict results
+          description: Bounding box to restrict results (min-lat,min-lng,max-lat,max-lng). Example for Scandinavia - 54.16243,4.04297,71.18316,31.81641
+        - name: force.add.postcode
+          in: query
+          schema:
+            type: boolean
+          description: Forcefully adds postcode to search response. Only works if Switzerland (CH) is specified in within.country parameter
+        - name: format.name
+          in: query
+          schema:
+            type: boolean
+          description: Format the name field to a well formatted, human-readable address of the location (experimental)
+        - name: format.exclude.country
+          in: query
+          schema:
+            type: boolean
+          description: Exclude the country from the formatted name field (only used if format.name is true)
       responses:
         '200':
           description: Successful response
@@ -1822,6 +2842,12 @@ paths:
                 $ref: '#/components/schemas/ResponseGeocodingResponse'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -1862,6 +2888,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/map-info:
     get:
@@ -1877,6 +2909,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseMapInfoResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/supported-locations:
     post:
@@ -1900,6 +2938,18 @@ paths:
                 $ref: '#/components/schemas/ResponseSupportedLocationsResponse'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Content
           content:
             application/json:
               schema:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -73,6 +73,28 @@ components:
           minimum: -180
           maximum: 180
 
+    CoordsOrH3:
+      oneOf:
+        - $ref: '#/components/schemas/Coords'
+        - type: object
+          required:
+            - h3_centroid
+          properties:
+            h3_centroid:
+              type: string
+              description: H3 index centroid of which will be treated as the location of departure. Mutually exclusive with lat and lng parameters.
+
+    CoordsOrGeohash:
+      oneOf:
+        - $ref: '#/components/schemas/Coords'
+        - type: object
+          required:
+            - geohash_centroid
+          properties:
+            geohash_centroid:
+              type: string
+              description: Geohash index centroid of which will be treated as the location of departure. Mutually exclusive with lat and lng parameters.
+
     RequestLocation:
       type: object
       required:
@@ -1236,7 +1258,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrH3'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -1263,7 +1285,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrH3'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -1323,7 +1345,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrH3'
         transportation:
           $ref: '#/components/schemas/RequestTransportationFast'
         travel_time:
@@ -1345,7 +1367,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrH3'
         transportation:
           $ref: '#/components/schemas/RequestTransportationFast'
         travel_time:
@@ -1427,7 +1449,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrGeohash'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -1454,7 +1476,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrGeohash'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -1514,7 +1536,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrGeohash'
         transportation:
           $ref: '#/components/schemas/RequestTransportationFast'
         travel_time:
@@ -1536,7 +1558,7 @@ components:
         id:
           $ref: '#/components/schemas/RequestSearchId'
         coords:
-          $ref: '#/components/schemas/Coords'
+          $ref: '#/components/schemas/CoordsOrGeohash'
         transportation:
           $ref: '#/components/schemas/RequestTransportationFast'
         travel_time:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -2425,6 +2425,92 @@ components:
 
 paths:
   /v4/time-filter:
+    get:
+      tags:
+        - Time Filter
+      summary: Time Filter GET (Simple Matrix Query)
+      description: |
+        Calculate travel times and distances from one search location to multiple target locations using a simple GET request.
+        For more complex queries with multiple searches, use the POST endpoint.
+        Note: Either departure_time or arrival_time must be specified (but not both).
+      operationId: timeFilterGet
+      parameters:
+        - name: app_id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Your TravelTime application ID
+        - name: api_key
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Your TravelTime API key
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - walking
+              - public_transport
+              - driving
+              - cycling
+          description: Mode of transport
+        - name: search_lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Latitude of the search location
+        - name: search_lng
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Longitude of the search location
+        - name: locations
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Coordinates of target locations in the format lat1_lng1,lat2_lng2,lat3_lng3 (e.g., 51.1234_0.1234,50.0000_-1.0000). Maximum 2,000 locations
+        - name: departure_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Departure time in ISO 8601 format (e.g., 2025-11-11T08:00:00Z). Either departure_time or arrival_time must be specified (but not both)
+        - name: arrival_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Arrival time in ISO 8601 format (e.g., 2025-11-11T08:00:00Z). Either departure_time or arrival_time must be specified (but not both)
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeFilterResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
         - Time Filter
@@ -2630,6 +2716,100 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /v4/routes:
+    get:
+      tags:
+        - Routes
+      summary: Routes GET (Simple Route)
+      description: |
+        Calculate a single route using a simple GET request with query parameters.
+        For more complex queries with multiple routes, use the POST endpoint.
+        Note: Either departure_time or arrival_time must be specified (but not both).
+      operationId: routesGet
+      parameters:
+        - name: app_id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Your TravelTime application ID
+        - name: api_key
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Your TravelTime API key
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - walking
+              - public_transport
+              - driving
+              - cycling
+          description: Mode of transport
+        - name: origin_lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Latitude of the start location
+        - name: origin_lng
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Longitude of the start location
+        - name: destination_lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Latitude of the destination location
+        - name: destination_lng
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Longitude of the destination location
+        - name: departure_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Departure time in ISO 8601 format (e.g., 2025-11-11T08:00:00Z). Either departure_time or arrival_time must be specified (but not both)
+        - name: arrival_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Arrival time in ISO 8601 format (e.g., 2025-11-11T08:00:00Z). Either departure_time or arrival_time must be specified (but not both)
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseRoutesResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
         - Routes
@@ -2671,6 +2851,94 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /v4/time-map:
+    get:
+      tags:
+        - Time Map
+      summary: Time Map GET (Simple Isochrone)
+      description: |
+        Generate a single isochrone polygon using a simple GET request with query parameters.
+        For more complex queries with multiple searches, unions, or intersections, use the POST endpoint.
+        Note: Either departure_time or arrival_time must be specified (but not both).
+      operationId: timeMapGet
+      parameters:
+        - name: app_id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Your TravelTime application ID
+        - name: api_key
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Your TravelTime API key
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - walking
+              - public_transport
+              - driving
+              - cycling
+          description: Mode of transport
+        - name: travel_time
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 60
+            maximum: 14400
+          description: Maximum journey time in seconds (up to 4 hours)
+        - name: lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Latitude of the search location
+        - name: lng
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Longitude of the search location
+        - name: departure_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Departure time in ISO 8601 format (e.g., 2025-11-11T08:00:00Z). Either departure_time or arrival_time must be specified (but not both)
+        - name: arrival_time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Arrival time in ISO 8601 format (e.g., 2025-11-11T08:00:00Z). Either departure_time or arrival_time must be specified (but not both)
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeMapResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
         - Time Map

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -82,7 +82,7 @@ components:
           properties:
             h3_centroid:
               type: string
-              description: H3 index centroid of which will be treated as the location of departure. Mutually exclusive with lat and lng parameters.
+              description: H3 index centroid of which will be treated as the location of departure or arrival. Mutually exclusive with lat and lng parameters.
 
     CoordsOrGeohash:
       oneOf:
@@ -93,7 +93,7 @@ components:
           properties:
             geohash_centroid:
               type: string
-              description: Geohash index centroid of which will be treated as the location of departure. Mutually exclusive with lat and lng parameters.
+              description: Geohash index centroid of which will be treated as the location of departure or arrival. Mutually exclusive with lat and lng parameters.
 
     RequestLocation:
       type: object

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -1844,6 +1844,49 @@ components:
           items:
             $ref: '#/components/schemas/ResponseTimeFilterResult'
 
+    ResponseTimeFilterGetProperties:
+      type: object
+      properties:
+        travel_time:
+          $ref: '#/components/schemas/ResponseTravelTime'
+
+    ResponseTimeFilterGetLocation:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        properties:
+          $ref: '#/components/schemas/ResponseTimeFilterGetProperties'
+
+    ResponseTimeFilterGetResult:
+      type: object
+      required:
+        - search_id
+        - locations
+      properties:
+        search_id:
+          type: string
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterGetLocation'
+        unreachable:
+          type: array
+          items:
+            type: string
+
+    ResponseTimeFilterGetResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterGetResult'
+
     ResponseTravelTimeStatistics:
       type: object
       required:
@@ -2498,7 +2541,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseTimeFilterResponse'
+                $ref: '#/components/schemas/ResponseTimeFilterGetResponse'
         '400':
           description: Bad request
           content:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -2,21 +2,42 @@ openapi: "3.1.0"
 
 info:
   title: TravelTime API
+  description: |
+    The TravelTime API allows you to calculate travel times, distances, and create isochrones using various transportation modes.
+    It provides endpoints for time filtering, route planning, geocoding, and specialized geographic analysis.
   termsOfService: https://www.traveltime.com/terms-and-conditions
   contact:
     name: API Support
     email: support@igeolise.com
-  version: 1.2.3
+  version: 1.3.0
 
 servers:
   - url: https://api.traveltimeapp.com
+    description: Production server
 
 externalDocs:
-  url: http://docs.traveltime.com
+  description: Full API Documentation
+  url: https://docs.traveltime.com/api/overview/introduction
 
 security:
   - ApplicationId: []
     ApiKey: []
+
+tags:
+  - name: Time Filter
+    description: Calculate travel times and distances between locations
+  - name: Time Map
+    description: Generate isochrone polygons showing reachable areas
+  - name: Routes
+    description: Calculate detailed routes with turn-by-turn directions
+  - name: Geocoding
+    description: Convert addresses to coordinates and vice versa
+  - name: Distance Map
+    description: Create distance-based catchment areas
+  - name: Specialized Analysis
+    description: H3, Geohash, and UK postcode analysis
+  - name: Utility
+    description: Map information and location support endpoints
 
 components:
   securitySchemes:
@@ -24,11 +45,13 @@ components:
       type: apiKey
       name: X-Application-Id
       in: header
+      description: Your TravelTime Application ID
     
     ApiKey:
       type: apiKey
       name: X-Api-Key
       in: header
+      description: Your TravelTime API Key
 
   schemas:
     Coords:
@@ -40,12 +63,31 @@ components:
         lat:
           type: number
           format: double
+          description: Latitude in decimal degrees
+          minimum: -90
+          maximum: 90
         lng:
           type: number
           format: double
+          description: Longitude in decimal degrees
+          minimum: -180
+          maximum: 180
+
+    RequestLocation:
+      type: object
+      required:
+        - id
+        - coords
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the location
+        coords:
+          $ref: '#/components/schemas/Coords'
 
     RequestSearchId:
       type: string
+      description: Unique identifier for the search
 
     RequestDepartureArrivalLocationOne:
       type: string
@@ -54,13 +96,22 @@ components:
       type: integer
       minimum: 60
       maximum: 14400
+      description: Maximum travel time in seconds (1 minute to 4 hours)
+
+    RequestTravelDistance:
+      type: integer
+      minimum: 75
+      maximum: 800000
+      description: Maximum travel distance in meters
 
     RequestDepartureArrivalTime:
       type: string
       format: date-time
+      description: Departure or arrival time in ISO 8601 format
 
     ResponseLocalTime:
       type: string
+      description: Local time at the location
 
     RequestRoutesProperty:
       type: string
@@ -86,6 +137,7 @@ components:
       type: integer
       minimum: 1
       maximum: 43200
+      description: Width of the search window in seconds
 
     RequestRangeFull:
       type: object
@@ -100,6 +152,7 @@ components:
           type: integer
           minimum: 1
           maximum: 5
+          description: Maximum number of results to return
         width:
           $ref: '#/components/schemas/RequestRangeWidth'
 
@@ -123,6 +176,9 @@ components:
     RequestTimeFilterPostcodeDistrictsReachablePostcodesThreshold:
       type: number
       format: double
+      minimum: 0
+      maximum: 1
+      description: Minimum percentage of postcodes that must be reachable
 
     RequestTimeFilterPostcodeDistrictsProperty:
       type: string
@@ -134,6 +190,8 @@ components:
     RequestTimeFilterPostcodeSectorsReachablePostcodesThreshold:
       type: number
       format: double
+      minimum: 0
+      maximum: 1
 
     RequestTimeFilterPostcodeSectorsProperty:
       type: string
@@ -155,6 +213,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -183,6 +243,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -211,6 +273,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -239,6 +303,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -266,6 +332,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -291,6 +359,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
         transportation:
           $ref: '#/components/schemas/RequestTransportation'
         travel_time:
@@ -376,6 +446,7 @@ components:
       type: string
       enum:
         - weekday_morning
+      description: Pre-defined time period for fast endpoints
     
     RequestTimeFilterFastProperty:
       type: string
@@ -447,6 +518,42 @@ components:
           items:
             $ref: '#/components/schemas/RequestTimeFilterFastProperty'
 
+    RequestTransportation:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - cycling
+            - driving
+            - driving+train
+            - public_transport
+            - walking
+            - coach
+            - bus
+            - train
+            - ferry
+            - driving+ferry
+            - cycling+ferry
+          description: Mode of transportation
+        pt_change_delay:
+          type: integer
+          description: Time in seconds for changing between public transport modes
+        walking_time:
+          type: integer
+          description: Maximum walking time in seconds
+        driving_time_to_station:
+          type: integer
+          description: Maximum driving time to station in seconds (for driving+train)
+        parking_time:
+          type: integer
+          description: Time in seconds for parking
+        boarding_time:
+          type: integer
+          description: Time in seconds for boarding
+
     RequestTransportationFast:
       type: object
       required:
@@ -458,6 +565,7 @@ components:
             - public_transport
             - driving
             - driving+public_transport
+          description: Transportation mode for fast endpoints
     
     RequestRoutesDepartureSearch:
       type: object
@@ -648,6 +756,9 @@ components:
           type: string
           enum:
             - simple
+            - simple_numeric
+            - coarse_grid
+          description: Type of scale for level of detail
         level:
           type: string
           enum:
@@ -656,6 +767,7 @@ components:
             - medium
             - high
             - highest
+          description: Level of detail for the polygon
 
     RequestUnionOnIntersection:
       type: object
@@ -669,6 +781,7 @@ components:
           type: array
           items:
             type: string
+          description: IDs of searches to union or intersect
 
     RequestTimeMapDepartureSearch:
       type: object
@@ -750,6 +863,92 @@ components:
           items:
             $ref: '#/components/schemas/RequestUnionOnIntersection'
 
+    RequestDistanceMapDepartureSearch:
+      type: object
+      required:
+        - id
+        - coords
+        - transportation
+        - travel_distance
+        - departure_time
+      properties:
+        id:
+          $ref: '#/components/schemas/RequestSearchId'
+        coords:
+          $ref: '#/components/schemas/Coords'
+        transportation:
+          $ref: '#/components/schemas/RequestTransportation'
+        travel_distance:
+          $ref: '#/components/schemas/RequestTravelDistance'
+        departure_time:
+          $ref: '#/components/schemas/RequestDepartureArrivalTime'
+        level_of_detail:
+          $ref: '#/components/schemas/RequestLevelOfDetail'
+
+    RequestDistanceMap:
+      type: object
+      required:
+        - departure_searches
+      properties:
+        departure_searches:
+          type: array
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/RequestDistanceMapDepartureSearch'
+
+    RequestGeocodingSearch:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: Address, postcode, or venue to geocode
+        within_country:
+          type: array
+          items:
+            type: string
+          description: Restrict results to specific countries (ISO 3166-1 alpha-2 or alpha-3)
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          description: Maximum number of results to return
+        bounds:
+          type: string
+          description: Bounding box to restrict results (min-lat,min-lng,max-lat,max-lng)
+        format_name:
+          type: boolean
+          description: Format the name field as a well-formatted address
+        format_exclude_country:
+          type: boolean
+          description: Exclude country from formatted name
+
+    RequestReverseGeocodingSearch:
+      type: object
+      required:
+        - lat
+        - lng
+      properties:
+        lat:
+          type: number
+          format: double
+          description: Latitude of the location
+        lng:
+          type: number
+          format: double
+          description: Longitude of the location
+
+    RequestSupportedLocations:
+      type: object
+      required:
+        - locations
+      properties:
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequestLocation'
+
     ResponseSearchId:
       type: string
 
@@ -758,9 +957,11 @@ components:
 
     ResponseTravelTime:
       type: integer
+      description: Travel time in seconds
 
     ResponseDistance:
       type: integer
+      description: Distance in meters
 
     ResponseTransportationMode:
       type: string
@@ -942,6 +1143,46 @@ components:
         route:
           $ref: '#/components/schemas/ResponseRoute'
 
+    ResponseTimeFilterLocation:
+      type: object
+      required:
+        - id
+        - properties
+      properties:
+        id:
+          type: string
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterProperties'
+
+    ResponseTimeFilterResult:
+      type: object
+      required:
+        - search_id
+        - locations
+      properties:
+        search_id:
+          type: string
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterLocation'
+        unreachable:
+          type: array
+          items:
+            type: string
+
+    ResponseTimeFilterResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterResult'
+
     ResponseTravelTimeStatistics:
       type: object
       required:
@@ -1009,32 +1250,6 @@ components:
         route:
           $ref: '#/components/schemas/ResponseRoute'
 
-    ResponseTimeFilterLocation:
-      type: object
-      required:
-        - id
-        - properties
-      properties:
-        id:
-          $ref: '#/components/schemas/ResponseLocationId'
-        properties:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterProperties'
-    
-    ResponseTimeFilterFastLocation:
-      type: object
-      required:
-        - id
-        - properties
-      properties:
-        id:
-          $ref: '#/components/schemas/ResponseLocationId'
-        properties:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterFastProperties'
-
     ResponseRoutesLocation:
       type: object
       required:
@@ -1042,131 +1257,20 @@ components:
         - properties
       properties:
         id:
-          $ref: '#/components/schemas/ResponseLocationId'
+          type: string
         properties:
           type: array
           items:
             $ref: '#/components/schemas/ResponseRoutesProperties'
-    
-    ResponseTimeFilterPostcode:
-      type: object
-      required:
-        - code
-        - properties
-      properties:
-        code:
-          type: string
-        properties:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodesProperties'
-
-    ResponseTimeFilterPostcodeDistrict:
-      type: object
-      required:
-        - code
-        - properties
-      properties:
-        code:
-          type: string
-        properties:
-          $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrictProperties'
-    
-    ResponseTimeFilterPostcodeSector:
-      type: object
-      required:
-        - code
-        - properties
-      properties:
-        code:
-          type: string
-        properties:
-          $ref: '#/components/schemas/ResponseTimeFilterPostcodeSectorProperties'
-
-    ResponseTimeFilterResult:
-      type: object
-      required:
-        - search_id
-        - locations
-        - unreachable
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        locations:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterLocation'
-        unreachable:
-          type: array
-          items:
-            type: string
-    
-    ResponseTimeFilterPostcodesResult:
-      type: object
-      required:
-        - search_id
-        - postcodes
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        postcodes:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcode'
-
-    ResponseTimeFilterPostcodeDistrictsResult:
-      type: object
-      required:
-        - search_id
-        - districts
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        districts:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrict'
-    
-    ResponseTimeFilterPostcodeSectorsResult:
-      type: object
-      required:
-        - search_id
-        - sectors
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        sectors:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodeSector'
-
-    ResponseTimeFilterFastResult:
-      type: object
-      required:
-        - search_id
-        - locations
-        - unreachable
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        locations:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterFastLocation'
-        unreachable:
-          type: array
-          items:
-            type: string
 
     ResponseRoutesResult:
       type: object
       required:
         - search_id
         - locations
-        - unreachable
       properties:
         search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
+          type: string
         locations:
           type: array
           items:
@@ -1176,57 +1280,7 @@ components:
           items:
             type: string
 
-    ResponseTimeFilter:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterResult'
-    
-    ResponseTimeFilterPostcodes:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodesResult'
-
-    ResponseTimeFilterPostcodeDistricts:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrictsResult'
-    
-    ResponseTimeFilterPostcodeSectors:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodeSectorsResult'
-
-    ResponseTimeFilterFast:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeFilterFastResult'
-
-    ResponseRoutes:
+    ResponseRoutesResponse:
       type: object
       required:
         - results
@@ -1236,83 +1290,38 @@ components:
           items:
             $ref: '#/components/schemas/ResponseRoutesResult'
 
-    ResponseShape:
-      type: object
-      required:
-        - shell
-        - holes
-      properties:
-        shell:
-          type: array
-          items:
-            $ref: '#/components/schemas/Coords'
-        holes:
-          type: array
-          items:
-            type: array
-            items:
-              $ref: '#/components/schemas/Coords'
-
-    ResponseBox:
-      type: object
-      required:
-        - min_lat
-        - max_lat
-        - min_lng
-        - max_lng
-      properties:
-        min_lat:
-          type: number
-          format: double
-        max_lat:
-          type: number
-          format: double
-        min_lng:
-          type: number
-          format: double
-        max_lng:
-          type: number
-          format: double
-
-    ResponseBoundingBox:
-      type: object
-      required:
-        - envelope
-        - boxes
-      properties:
-        envelope:
-          $ref: '#/components/schemas/ResponseBox'
-        boxes:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseBox'
-
-    ResponseTimeMapProperties:
-      type: object
-      properties:
-        is_only_walking:
-          type: boolean
-
-    ResponseWktShape:
-      type: string
-
     ResponseTimeMapResult:
       type: object
       required:
         - search_id
         - shapes
-        - properties
       properties:
         search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
+          type: string
         shapes:
           type: array
           items:
-            $ref: '#/components/schemas/ResponseShape'
+            type: object
+            required:
+              - shell
+            properties:
+              shell:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Coords'
+              holes:
+                type: array
+                items:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Coords'
         properties:
-          $ref: '#/components/schemas/ResponseTimeMapProperties'
+          type: object
+          properties:
+            is_only_walking:
+              type: boolean
 
-    ResponseTimeMap:
+    ResponseTimeMapResponse:
       type: object
       required:
         - results
@@ -1322,93 +1331,81 @@ components:
           items:
             $ref: '#/components/schemas/ResponseTimeMapResult'
 
-    ResponseTimeMapWktResult:
-      type: object
-      required:
-        - search_id
-        - shape
-        - properties
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        shape:
-          $ref: '#/components/schemas/ResponseWktShape'
-        properties:
-          $ref: '#/components/schemas/ResponseTimeMapProperties'
-
-    ResponseTimeMapWkt:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeMapWktResult'
-
-    ResponseTimeMapBoundingBoxesResult:
-      type: object
-      required:
-        - search_id
-        - bounding_boxes
-        - properties
-      properties:
-        search_id:
-          $ref: '#/components/schemas/ResponseSearchId'
-        bounding_boxes:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseBoundingBox'
-        properties:
-          $ref: '#/components/schemas/ResponseTimeMapProperties'
-
-    ResponseTimeMapBoundingBoxes:
-      type: object
-      required:
-        - results
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseTimeMapBoundingBoxesResult'
-
-    RequestTransportation:
+    ResponseGeocodingFeature:
       type: object
       required:
         - type
+        - geometry
+        - properties
       properties:
         type:
           type: string
           enum:
-            - cycling
-            - driving
-            - driving+train
-            - public_transport
-            - walking
-            - coach
-            - bus
-            - train
-            - ferry
-            - driving+ferry
-            - cycling+ferry
-            - cycling+public_transport
-        disable_border_crossing:
-          type: boolean
-        pt_change_delay:
-          type: integer
-        walking_time:
-          type: integer
-        driving_time_to_station:
-          type: integer
-        cycling_time_to_station:
-          type: integer
-        parking_time:
-          type: integer
-        boarding_time:
-          type: integer
+            - Feature
+        geometry:
+          type: object
+          required:
+            - type
+            - coordinates
+          properties:
+            type:
+              type: string
+              enum:
+                - Point
+            coordinates:
+              type: array
+              items:
+                type: number
+              minItems: 2
+              maxItems: 2
+        properties:
+          type: object
+          properties:
+            name:
+              type: string
+            label:
+              type: string
+            score:
+              type: number
+            house_number:
+              type: string
+            street:
+              type: string
+            region:
+              type: string
+            region_code:
+              type: string
+            neighbourhood:
+              type: string
+            county:
+              type: string
+            macroregion:
+              type: string
+            city:
+              type: string
+            country:
+              type: string
+            country_code:
+              type: string
+            continent:
+              type: string
 
-    RequestLocationId:
-      type: string
+    ResponseGeocodingResponse:
+      type: object
+      required:
+        - type
+        - features
+      properties:
+        type:
+          type: string
+          enum:
+            - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseGeocodingFeature'
+        attribution:
+          type: string
 
     ResponseSupportedLocation:
       type: object
@@ -1420,8 +1417,12 @@ components:
           type: string
         map_name:
           type: string
+        additional_map_names:
+          type: array
+          items:
+            type: string
 
-    ResponseSupportedLocations:
+    ResponseSupportedLocationsResponse:
       type: object
       required:
         - locations
@@ -1436,154 +1437,15 @@ components:
           items:
             type: string
 
-    RequestSupportedLocations:
-      type: object
-      required:
-        - locations
-      properties:
-        locations:
-          type: array
-          minItems: 1
-          items:
-            $ref: '#/components/schemas/RequestLocation'
-
-    RequestLocation:
-      type: object
-      required:
-        - id
-        - coords
-      properties:
-        id:
-          $ref: '#/components/schemas/RequestLocationId'
-        coords:
-          $ref: '#/components/schemas/Coords'
-
-    ResponseError:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/error-response
-      type: object
-      properties:
-        http_status:
-          type: integer
-        error_code:
-          type: integer
-        description:
-          type: string
-        documentation_link:
-          type: string
-        additional_info:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-
-    ResponseGeocodingGeometry:
-      type: object
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-        coordinates:
-          type: array
-          items:
-            type: number
-            format: double
-
-    ResponseMapInfoFeaturesPublicTransport:
-      type: object
-      required:
-        - date_start
-        - date_end
-      properties:
-        date_start:
-          type: string
-          format: date-time
-        date_end:
-          type: string
-          format: date-time
-    
     ResponseMapInfoFeatures:
       type: object
-      required:
-        - fares
-        - postcodes
       properties:
-        public_transport:
-          $ref: '#/components/schemas/ResponseMapInfoFeaturesPublicTransport'
         fares:
           type: boolean
         postcodes:
           type: boolean
-
-    ResponseGeocodingProperties:
-      type: object
-      required:
-        - name
-        - label
-      properties:
-        name:
-          type: string
-        label:
-          type: string
-        score:
-          type: number
-          format: double
-        house_number:
-          type: string
-        street:
-          type: string
-        region:
-          type: string
-        region_code:
-          type: string
-        neighbourhood:
-          type: string
-        county:
-          type: string
-        macroregion:
-          type: string
-        city:
-          type: string
-        country:
-          type: string
-        country_code:
-          type: string
-        continent:
-          type: string
-        postcode:
-          type: string
-        features:
-          $ref: '#/components/schemas/ResponseMapInfoFeatures'
-    
-    ResponseGeocodingGeoJsonFeature:
-      type: object
-      required:
-        - type
-        - geometry
-        - properties
-      properties:
-        type:
-          type: string
-        geometry:
-          $ref: '#/components/schemas/ResponseGeocodingGeometry'
-        properties:
-          $ref: '#/components/schemas/ResponseGeocodingProperties'
-    
-    ResponseGeocoding:
-      type: object
-      required:
-        - type
-        - features
-      properties:
-        type:
-          type: string
-        features:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResponseGeocodingGeoJsonFeature'
+        public_transport:
+          type: boolean
 
     ResponseMapInfoMap:
       type: object
@@ -1596,7 +1458,7 @@ components:
         features:
           $ref: '#/components/schemas/ResponseMapInfoFeatures'
 
-    ResponseMapInfo:
+    ResponseMapInfoResponse:
       type: object
       required:
         - maps
@@ -1606,338 +1468,373 @@ components:
           items:
             $ref: '#/components/schemas/ResponseMapInfoMap'
 
-  requestBodies:
-    TimeFilter:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestTimeFilter'
-    
-    TimeFilterPostcodes:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestTimeFilterPostcodes'
-
-    TimeFilterPostcodeDistricts:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestTimeFilterPostcodeDistricts'
-
-    TimeFilterPostcodeSectors:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestTimeFilterPostcodeSectors'
-
-    TimeFilterFast:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestTimeFilterFast'
-
-    Routes:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestRoutes'
-
-    TimeMap:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestTimeMap'
-
-    SupportedLocations:
-      required: true
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/RequestSupportedLocations'
-
-  responses:
-    Error:
-      description: 'The json body returned upon error. [Docs link](http://docs.traveltime.com/reference/error-response)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseError'
-
-    TimeFilter:
-      description: 'Given origin and destination points filter out points that cannot be reached within specified time limit. [Docs link](http://docs.traveltime.com/reference/time-filter)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeFilter'
-    
-    TimeFilterPostcodes:
-      description: 'Find reachable postcodes from origin and get statistics about such postcodes. [Docs link](http://docs.traveltime.com/reference/postcode-search/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodes'
-
-    TimeFilterPostcodeDistricts:
-      description: 'Find districts that have a certain coverage from origin and get statistics about postcodes within such districts. [Docs link](http://docs.traveltime.com/reference/postcode-district-filter/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistricts'
-    
-    TimeFilterPostcodeSectors:
-      description: 'Find sectors that have a certain coverage from origin and get statistics about postcodes within such sectors. [Docs link](http://docs.traveltime.com/reference/postcode-sector-filter/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeFilterPostcodeSectors'
-    
-    TimeFilterFast:
-      description: 'A very fast version of Time Filter. [Docs link](http://docs.traveltime.com/reference/time-filter-fast/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeFilterFast'
-
-    Routes:
-      description: 'Returns routing information between source and destinations. [Docs link](http://docs.traveltime.com/reference/routes/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseRoutes'
-    
-    Geocoding:
-      description: 'Match a query string to geographic coordinates. [Docs link](http://docs.traveltime.com/reference/geocoding-search/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseGeocoding'
-
-    TimeMap:
-      description: 'Given origin coordinates, find shapes of zones reachable within corresponding travel time. [Docs link](http://docs.traveltime.com/reference/time-map/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeMap'
-        'application/vnd.wkt+json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeMapWkt'
-        'application/vnd.wkt-no-holes+json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeMapWkt'
-        'application/vnd.bounding-boxes+json':
-          schema:
-            $ref: '#/components/schemas/ResponseTimeMapBoundingBoxes'
-
-    MapInfo:
-      description: 'Returns information about currently supported countries. [Docs link](http://docs.traveltime.com/reference/map-info/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseMapInfo'
-
-    SupportedLocations:
-      description: 'Find out what points are supported by our api. [Docs link](http://docs.traveltime.com/reference/supported-locations/)'
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/ResponseSupportedLocations'
-
-  parameters:
-    GeocodingWithinCountry:
-      name: within.country
-      in: query
-      schema:
-        type: string
-    
-    GeocodingQuery:
-      name: query
-      in: query
-      required: true
-      schema:
-        type: string
-    
-    GeocodingFocusLat:
-      name: focus.lat
-      in: query
-      schema:
-        type: number
-        format: double
-    
-    GeocodingFocusLng:
-      name: focus.lng
-      in: query
-      schema:
-        type: number
-        format: double
-    
-    GeocodingReverseLat:
-      name: lat
-      in: query
-      required: true
-      schema:
-        type: number
-        format: double
-    
-    GeocodingReverseLng:
-      name: lng
-      in: query
-      required: true
-      schema:
-        type: number
-        format: double
-
+    ErrorResponse:
+      type: object
+      required:
+        - error_code
+        - description
+      properties:
+        error_code:
+          type: integer
+        description:
+          type: string
+        documentation_link:
+          type: string
+        additional_info:
+          type: object
 
 paths:
   /v4/time-filter:
     post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/time-filter
+      tags:
+        - Time Filter
+      summary: Time Filter (Time Matrix)
+      description: |
+        Calculate travel times and distances between multiple origins and destinations.
+        Supports up to 2,000 locations per search with customizable parameters.
       operationId: timeFilter
       requestBody:
-        $ref: '#/components/requestBodies/TimeFilter'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeFilter'
       responses:
         '200':
-          $ref: '#/components/responses/TimeFilter'
-        default:
-          $ref: '#/components/responses/Error'
-      
-  /v4/time-filter/postcodes:
-    post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/postcode-search
-      operationId: timeFilterPostcodes
-      requestBody:
-        $ref: '#/components/requestBodies/TimeFilterPostcodes'
-      responses:
-        '200':
-          $ref: '#/components/responses/TimeFilterPostcodes'
-        default:
-          $ref: '#/components/responses/Error'
-  
-  /v4/time-filter/postcode-districts:
-    post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/postcode-search
-      operationId: timeFilterPostcodeDistricts
-      requestBody:
-        $ref: '#/components/requestBodies/TimeFilterPostcodeDistricts'
-      responses:
-        '200':
-          $ref: '#/components/responses/TimeFilterPostcodeDistricts'
-        default:
-          $ref: '#/components/responses/Error'
-  
-  /v4/time-filter/postcode-sectors:
-    post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/postcode-sector-filter
-      operationId: timeFilterPostcodeSectors
-      requestBody:
-        $ref: '#/components/requestBodies/TimeFilterPostcodeSectors'
-      responses:
-        '200':
-          $ref: '#/components/responses/TimeFilterPostcodeSectors'
-        default:
-          $ref: '#/components/responses/Error'
-  
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeFilterResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /v4/time-filter/fast:
     post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/time-filter-fast
+      tags:
+        - Time Filter
+      summary: Time Filter Fast
+      description: |
+        High-performance endpoint for calculating travel times between up to 100,000 locations.
+        Uses pre-computed data for faster response times.
       operationId: timeFilterFast
       requestBody:
-        $ref: '#/components/requestBodies/TimeFilterFast'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeFilterFast'
       responses:
         '200':
-          $ref: '#/components/responses/TimeFilterFast'
-        default:
-          $ref: '#/components/responses/Error'
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeFilterResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
-  /v4/time-map:
+  /v4/time-filter/postcodes:
     post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/time-map
-      operationId: timeMap
+      tags:
+        - Specialized Analysis
+      summary: Time Filter Postcodes
+      description: Filter UK postcodes by travel time
+      operationId: timeFilterPostcodes
       requestBody:
-        $ref: '#/components/requestBodies/TimeMap'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeFilterPostcodes'
       responses:
         '200':
-          $ref: '#/components/responses/TimeMap'
-        default:
-          $ref: '#/components/responses/Error'
+          description: Successful response
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/time-filter/postcode-districts:
+    post:
+      tags:
+        - Specialized Analysis
+      summary: Time Filter Postcode Districts
+      description: Filter UK postcode districts by travel time
+      operationId: timeFilterPostcodeDistricts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeFilterPostcodeDistricts'
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/time-filter/postcode-sectors:
+    post:
+      tags:
+        - Specialized Analysis
+      summary: Time Filter Postcode Sectors
+      description: Filter UK postcode sectors by travel time
+      operationId: timeFilterPostcodeSectors
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeFilterPostcodeSectors'
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v4/routes:
     post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/routes
+      tags:
+        - Routes
+      summary: Routes
+      description: |
+        Calculate detailed routes with turn-by-turn directions between locations.
+        Supports multiple transportation modes and returns route geometry.
       operationId: routes
       requestBody:
-        $ref: '#/components/requestBodies/Routes'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestRoutes'
       responses:
         '200':
-          $ref: '#/components/responses/Routes'
-        default:
-          $ref: '#/components/responses/Error'
-  
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseRoutesResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/time-map:
+    post:
+      tags:
+        - Time Map
+      summary: Time Map (Isochrones)
+      description: |
+        Generate isochrone polygons showing areas reachable within a given travel time.
+        Returns polygon coordinates that can be visualized on a map.
+      operationId: timeMap
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestTimeMap'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeMapResponse'
+            application/geo+json:
+              schema:
+                type: object
+                description: GeoJSON FeatureCollection with isochrone polygons
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v4/distance-map:
+    post:
+      tags:
+        - Distance Map
+      summary: Distance Map
+      description: |
+        Generate isodistance polygons showing areas reachable within a given travel distance.
+        Similar to time-map but based on distance rather than time.
+      operationId: distanceMap
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestDistanceMap'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeMapResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /v4/geocoding/search:
     get:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/geocoding-search
+      tags:
+        - Geocoding
+      summary: Geocoding Search
+      description: Convert address or place name to coordinates (forward geocoding)
       operationId: geocodingSearch
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Address, postcode, or venue to geocode
+        - name: within.country
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          description: Restrict results to specific countries
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+          description: Maximum number of results
+        - name: bounds
+          in: query
+          schema:
+            type: string
+          description: Bounding box to restrict results
       responses:
         '200':
-          $ref: '#/components/responses/Geocoding'
-        default:
-          $ref: '#/components/responses/Error'
-      parameters:
-        - $ref: '#/components/parameters/GeocodingQuery'
-        - $ref: '#/components/parameters/GeocodingFocusLat'
-        - $ref: '#/components/parameters/GeocodingFocusLng'
-        - $ref: '#/components/parameters/GeocodingWithinCountry'
-  
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseGeocodingResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /v4/geocoding/reverse:
     get:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/geocoding-reverse
-      operationId: geocodingReverseSearch
+      tags:
+        - Geocoding
+      summary: Reverse Geocoding
+      description: Convert coordinates to address (reverse geocoding)
+      operationId: reverseGeocoding
+      parameters:
+        - name: lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Latitude coordinate
+        - name: lng
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+          description: Longitude coordinate
       responses:
         '200':
-          $ref: '#/components/responses/Geocoding'
-        default:
-          $ref: '#/components/responses/Error'
-      parameters:
-        - $ref: '#/components/parameters/GeocodingReverseLat'
-        - $ref: '#/components/parameters/GeocodingReverseLng'
-        - $ref: '#/components/parameters/GeocodingWithinCountry'
-  
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseGeocodingResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /v4/map-info:
     get:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/map-info
+      tags:
+        - Utility
+      summary: Map Info
+      description: Get information about supported countries and features
       operationId: mapInfo
       responses:
         '200':
-          $ref: '#/components/responses/MapInfo'
-        default:
-          $ref: '#/components/responses/Error'
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseMapInfoResponse'
 
   /v4/supported-locations:
     post:
-      externalDocs:
-        url: http://docs.traveltime.com/reference/supported-locations
+      tags:
+        - Utility
+      summary: Supported Locations
+      description: Check if specific locations are supported by the API
       operationId: supportedLocations
       requestBody:
-        $ref: '#/components/requestBodies/SupportedLocations'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestSupportedLocations'
       responses:
         '200':
-          $ref: '#/components/responses/SupportedLocations'
-        default:
-          $ref: '#/components/responses/Error'
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseSupportedLocationsResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -554,6 +554,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RequestTimeFilterFastProperty'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
 
     RequestTimeFilterFastArrivalOneToManySearch:
       type: object
@@ -586,6 +588,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RequestTimeFilterFastProperty'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
 
     RequestTransportation:
       type: object
@@ -612,24 +616,31 @@ components:
         pt_change_delay:
           type: integer
           description: Time in seconds for changing between public transport modes
+          default: 0
         walking_time:
           type: integer
           description: Maximum walking time in seconds
+          default: 900
         driving_time_to_station:
           type: integer
           description: Maximum driving time to station in seconds (for driving+train)
+          default: 1800
         cycling_time_to_station:
           type: integer
           description: Maximum cycling time to station in seconds (for cycling+public_transport)
+          default: 900
         parking_time:
           type: integer
           description: Time in seconds for parking
+          default: 300
         boarding_time:
           type: integer
           description: Time in seconds for boarding
+          default: 0
         disable_border_crossing:
           type: boolean
           description: Disable crossing country borders (driving only)
+          default: false
         include_roads:
           type: array
           items:
@@ -650,8 +661,11 @@ components:
           properties:
             enabled:
               type: boolean
+              description: Enable transit leg change limit?
             limit:
               type: integer
+              description: Maximum number of changes between transit legs in a journey.
+          description: Upper limit for the number of changes between public transit legs in a journey.
 
     RequestTransportationFast:
       type: object
@@ -1662,6 +1676,26 @@ components:
           format: double
         currency:
           type: string
+          description: ISO 4217 currency code.
+    
+    ResponseFareTicketFast:
+      type: object
+      required:
+        - type
+        - price
+        - currency
+      properties:
+        type:
+          type: string
+          enum:
+            - month
+            - year
+        price:
+          type: number
+          format: double
+        currency:
+          type: string
+          description: ISO 4217 currency code.
 
     ResponseFaresBreakdownItem:
       type: object
@@ -1678,6 +1712,7 @@ components:
           type: array
           items:
             type: integer
+          description: Id's of route parts that are covered by these tickets.
         tickets:
           type: array
           items:
@@ -1706,7 +1741,7 @@ components:
         tickets_total:
           type: array
           items:
-            $ref: '#/components/schemas/ResponseFareTicket'
+            $ref: '#/components/schemas/ResponseFareTicketFast'
 
     ResponseRoutePart:
       type: object
@@ -1803,6 +1838,16 @@ components:
           $ref: '#/components/schemas/ResponseFares'
         route:
           $ref: '#/components/schemas/ResponseRoute'
+    
+    ResponseTimeFilterPropertiesFast:
+      type: object
+      properties:
+        travel_time:
+          $ref: '#/components/schemas/ResponseTravelTime'
+        distance:
+          $ref: '#/components/schemas/ResponseDistance'
+        fares:
+          $ref: '#/components/schemas/ResponseFaresFast'
 
     ResponseTimeFilterLocation:
       type: object
@@ -1816,6 +1861,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ResponseTimeFilterProperties'
+    
+    ResponseTimeFilterLocationFast:
+      type: object
+      required:
+        - id
+        - properties
+      properties:
+        id:
+          type: string
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPropertiesFast'
 
     ResponseTimeFilterResult:
       type: object
@@ -1833,6 +1891,23 @@ components:
           type: array
           items:
             type: string
+    
+    ResponseTimeFilterResultFast:
+      type: object
+      required:
+        - search_id
+        - locations
+      properties:
+        search_id:
+          type: string
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterLocationFast'
+        unreachable:
+          type: array
+          items:
+            type: string
 
     ResponseTimeFilterResponse:
       type: object
@@ -1843,6 +1918,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ResponseTimeFilterResult'
+    
+    ResponseTimeFilterResponseFast:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterResultFast'
 
     ResponseTimeFilterGetProperties:
       type: object
@@ -2671,7 +2756,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseTimeFilterResponse'
+                $ref: '#/components/schemas/ResponseTimeFilterResponseFast'
         '400':
           description: Bad request
           content:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -1891,6 +1891,108 @@ components:
           type: number
           format: double
 
+    ResponseTimeFilterPostcode:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: Postcode code
+        properties:
+          $ref: '#/components/schemas/ResponseTimeFilterPostcodesProperties'
+
+    ResponseTimeFilterPostcodesResult:
+      type: object
+      required:
+        - search_id
+        - postcodes
+      properties:
+        search_id:
+          type: string
+        postcodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPostcode'
+
+    ResponseTimeFilterPostcodesResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPostcodesResult'
+
+    ResponseTimeFilterPostcodeDistrict:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: Postcode district code
+        properties:
+          $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrictProperties'
+
+    ResponseTimeFilterPostcodeDistrictsResult:
+      type: object
+      required:
+        - search_id
+        - districts
+      properties:
+        search_id:
+          type: string
+        districts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrict'
+
+    ResponseTimeFilterPostcodeDistrictsResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrictsResult'
+
+    ResponseTimeFilterPostcodeSector:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: Postcode sector code
+        properties:
+          $ref: '#/components/schemas/ResponseTimeFilterPostcodeSectorProperties'
+
+    ResponseTimeFilterPostcodeSectorsResult:
+      type: object
+      required:
+        - search_id
+        - sectors
+      properties:
+        search_id:
+          type: string
+        sectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPostcodeSector'
+
+    ResponseTimeFilterPostcodeSectorsResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterPostcodeSectorsResult'
+
     ResponseTimeFilterFastProperties:
       type: object
       properties:
@@ -2426,6 +2528,10 @@ paths:
       responses:
         '200':
           description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeFilterPostcodesResponse'
         '400':
           description: Bad request
           content:
@@ -2461,6 +2567,10 @@ paths:
       responses:
         '200':
           description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeFilterPostcodeDistrictsResponse'
         '400':
           description: Bad request
           content:
@@ -2496,6 +2606,10 @@ paths:
       responses:
         '200':
           description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseTimeFilterPostcodeSectorsResponse'
         '400':
           description: Bad request
           content:

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -235,6 +235,28 @@ components:
           type: integer
           description: Maximum distance in meters between locations and the nearest accessible road. Default is 1000 meters. Departure locations exceeding this return errors, arrival locations return unreachable results
           default: 1000
+    
+    RequestSnappingH3:
+      type: object
+      properties:
+        penalty:
+          type: string
+          enum:
+            - enabled
+            - disabled
+          description: |
+            Controls whether walking distances to/from the nearest road are included in travel time/distance.
+            - enabled (default): Walking time/distance from departure to nearest road and from nearest road to arrival are added to totals
+            - disabled: Journey starts/ends at the nearest road network point, excluding walking portions
+        accept_roads:
+          type: string
+          enum:
+            - both_drivable_and_walkable
+            - any_drivable
+          description: |
+            Controls which road types can serve as journey start/end points.
+            - both_drivable_and_walkable (default): Only roads accessible by both cars and pedestrians, preventing routes from starting/ending on motorways
+            - any_drivable: Any road accessible by car, including motorways
 
     RequestTimeFilterPostcodesProperty:
       type: string
@@ -1268,7 +1290,7 @@ components:
         range:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3'
         remove_water_bodies:
           type: boolean
           description: Remove water bodies from the results
@@ -1295,7 +1317,7 @@ components:
         range:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3'
         remove_water_bodies:
           type: boolean
           description: Remove water bodies from the results
@@ -1353,7 +1375,7 @@ components:
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3'
 
     RequestH3FastArrivalOneToManySearch:
       type: object
@@ -1375,7 +1397,7 @@ components:
         arrival_time_period:
           $ref: '#/components/schemas/RequestArrivalTimePeriod'
         snapping:
-          $ref: '#/components/schemas/RequestSnapping'
+          $ref: '#/components/schemas/RequestSnappingH3'
 
     RequestH3FastArrivalSearches:
       type: object

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -120,6 +120,7 @@ components:
         - distance
         - fares
         - route
+      description: Properties to return for route searches
 
     RequestTimeFilterProperty:
       type: string
@@ -129,9 +130,11 @@ components:
         - distance_breakdown
         - fares
         - route
+      description: Properties to return for time filter searches
 
     RequestRangeEnabled:
       type: boolean
+      description: Enable range-based search
 
     RequestRangeWidth:
       type: integer
@@ -166,6 +169,21 @@ components:
           $ref: '#/components/schemas/RequestRangeEnabled'
         width:
           $ref: '#/components/schemas/RequestRangeWidth'
+
+    RequestSnapping:
+      type: object
+      properties:
+        penalty:
+          type: string
+          enum:
+            - enabled
+            - disabled
+          description: Control road network lookup behavior
+        accept_roads:
+          type: array
+          items:
+            type: string
+          description: List of road types to accept
 
     RequestTimeFilterPostcodesProperty:
       type: string
@@ -407,6 +425,8 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
 
     RequestTimeFilterArrivalSearch:
       type: object
@@ -441,6 +461,8 @@ components:
             $ref: '#/components/schemas/RequestTimeFilterProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
 
     RequestArrivalTimePeriod:
       type: string
@@ -537,6 +559,7 @@ components:
             - ferry
             - driving+ferry
             - cycling+ferry
+            - cycling+public_transport
           description: Mode of transportation
         pt_change_delay:
           type: integer
@@ -547,12 +570,25 @@ components:
         driving_time_to_station:
           type: integer
           description: Maximum driving time to station in seconds (for driving+train)
+        cycling_time_to_station:
+          type: integer
+          description: Maximum cycling time to station in seconds (for cycling+public_transport)
         parking_time:
           type: integer
           description: Time in seconds for parking
         boarding_time:
           type: integer
           description: Time in seconds for boarding
+        disable_border_crossing:
+          type: boolean
+          description: Disable crossing country borders (driving only)
+        max_changes:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            limit:
+              type: integer
 
     RequestTransportationFast:
       type: object
@@ -564,6 +600,11 @@ components:
           enum:
             - public_transport
             - driving
+            - cycling
+            - walking
+            - walking+ferry
+            - cycling+ferry
+            - driving+ferry
             - driving+public_transport
           description: Transportation mode for fast endpoints
     
@@ -597,6 +638,8 @@ components:
             $ref: '#/components/schemas/RequestRoutesProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
 
     RequestRoutesArrivalSearch:
       type: object
@@ -628,6 +671,8 @@ components:
             $ref: '#/components/schemas/RequestRoutesProperty'
         range:
           $ref: '#/components/schemas/RequestRangeFull'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
 
     RequestTimeFilter:
       type: object
@@ -748,9 +793,6 @@ components:
 
     RequestLevelOfDetail:
       type: object
-      required:
-        - scale_type
-        - level
       properties:
         scale_type:
           type: string
@@ -768,6 +810,17 @@ components:
             - high
             - highest
           description: Level of detail for the polygon
+
+    RequestPolygonsFilter:
+      type: object
+      properties:
+        largest_area:
+          type: boolean
+          description: Only return the largest polygon
+        smallest_inner_area:
+          type: number
+          format: double
+          description: Minimum area of inner holes to include
 
     RequestUnionOnIntersection:
       type: object
@@ -810,6 +863,13 @@ components:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         level_of_detail:
           $ref: '#/components/schemas/RequestLevelOfDetail'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        polygons_filter:
+          $ref: '#/components/schemas/RequestPolygonsFilter'
+        remove_water_bodies:
+          type: boolean
+          description: Remove water bodies from the polygons
 
     RequestTimeMapArrivalSearch:
       type: object
@@ -838,6 +898,12 @@ components:
           $ref: '#/components/schemas/RequestRangeNoMaxResults'
         level_of_detail:
           $ref: '#/components/schemas/RequestLevelOfDetail'
+        snapping:
+          $ref: '#/components/schemas/RequestSnapping'
+        polygons_filter:
+          $ref: '#/components/schemas/RequestPolygonsFilter'
+        remove_water_bodies:
+          type: boolean
 
     RequestTimeMap:
       type: object

--- a/traveltime-spec.yml
+++ b/traveltime-spec.yml
@@ -1620,6 +1620,7 @@ components:
         - boarding
         - walk
         - bike
+        - bike_parking
         - train
         - rail_national
         - rail_overground
@@ -1719,7 +1720,8 @@ components:
         - coords
       properties:
         id:
-          type: string
+          type: integer
+          description: A sequential id, used to relate route parts with fare data
         type:
           type: string
           enum:
@@ -1727,10 +1729,12 @@ components:
             - start_end
             - road
             - public_transport
+          description: Type of route part
         mode:
           $ref: '#/components/schemas/ResponseTransportationMode'
         directions:
           type: string
+          description: Human-readable directions for this part
         distance:
           $ref: '#/components/schemas/ResponseDistance'
         travel_time:
@@ -1739,24 +1743,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Coords'
+          description: Coordinates along this route part
         direction:
           type: string
+          description: Only available when type is start_end
         road:
           type: string
+          description: Road name. May be present on parts where type is road
         turn:
           type: string
+          description: Turn direction. May be present on parts where type is road
         line:
           type: string
+          description: Public transport line name. Only available when type is public_transport
         departure_station:
           type: string
+          description: Departure station name. Only available when type is public_transport
         arrival_station:
           type: string
+          description: Arrival station name. Only available when type is public_transport
         departs_at:
           $ref: '#/components/schemas/ResponseLocalTime'
         arrives_at:
           $ref: '#/components/schemas/ResponseLocalTime'
         num_stops:
           type: integer
+          description: Number of stops. Only available when type is public_transport
 
     ResponseRoute:
       type: object
@@ -1982,6 +1994,58 @@ components:
           items:
             $ref: '#/components/schemas/ResponseTimeMapResult'
 
+    ResponsePublicTransportInfo:
+      type: object
+      properties:
+        date_start:
+          type: string
+          format: date
+          description: Start date of public transport data availability
+        date_end:
+          type: string
+          format: date
+          description: End date of public transport data availability
+
+    ResponseTimeFilterFastPeriod:
+      type: object
+      properties:
+        time_period:
+          type: string
+        supported:
+          type: array
+          items:
+            type: object
+            properties:
+              search_type:
+                type: string
+              transportation_mode:
+                type: string
+
+    ResponseTimeFilterFastInfo:
+      type: object
+      properties:
+        periods:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseTimeFilterFastPeriod'
+
+    ResponseLocationFeatures:
+      type: object
+      description: Available TravelTime API features for this location
+      properties:
+        public_transport:
+          $ref: '#/components/schemas/ResponsePublicTransportInfo'
+        postcode:
+          type: boolean
+        fares:
+          type: boolean
+        cross_country_modes:
+          type: array
+          items:
+            type: string
+        time_filter_fast:
+          $ref: '#/components/schemas/ResponseTimeFilterFastInfo'
+
     ResponseGeocodingFeature:
       type: object
       required:
@@ -2009,15 +2073,19 @@ components:
                 type: number
               minItems: 2
               maxItems: 2
+              description: Coordinates in [longitude, latitude] format
         properties:
           type: object
           properties:
             name:
               type: string
+              description: Well formatted, human-readable address of the location (if format.name=true)
             label:
               type: string
+              description: Full formatted address
             score:
               type: number
+              description: Relevance score for the search result
             house_number:
               type: string
             street:
@@ -2040,6 +2108,22 @@ components:
               type: string
             continent:
               type: string
+            postcode:
+              type: string
+            local_admin:
+              type: string
+            district:
+              type: string
+            town:
+              type: string
+            category:
+              type: string
+              description: Category of the location
+            type:
+              type: string
+              description: Type of the location
+            features:
+              $ref: '#/components/schemas/ResponseLocationFeatures'
 
     ResponseGeocodingResponse:
       type: object
@@ -2192,26 +2276,9 @@ components:
           type: boolean
           description: Indicates whether or not postcode searches are supported
         public_transport:
-          type: object
-          description: Public transport support information. Public transport is not supported if this object is missing.
-          properties:
-            date_start:
-              type: string
-              format: date-time
-              description: Start date of public transport data availability
-            date_end:
-              type: string
-              format: date-time
-              description: End date of public transport data availability
+          $ref: '#/components/schemas/ResponsePublicTransportInfo'
         time_filter_fast:
-          type: object
-          description: Fast time-filter support information. The endpoint is not supported if this object is missing.
-          properties:
-            periods:
-              type: array
-              items:
-                type: object
-                description: Each entry describes a time period and time filter modes that are available for this country
+          $ref: '#/components/schemas/ResponseTimeFilterFastInfo'
         cross_country_modes:
           type: array
           items:


### PR DESCRIPTION
Updated the TravelTime API specification to version 1.3.0. Added detailed descriptions for various endpoints and components, including new tags for better organization.